### PR TITLE
delete example lua-language-server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -972,33 +972,7 @@ For more information on how to configure `luacheck`, please refer to its [docume
 
 #### sumneko/lua-language-server
 
-Example configuration for [sumneko/lua-language-server](https://github.com/sumneko/lua-language-server/) (the example uses the built-in LSP client but the configuration should be identical for other LSP client implementations):
-
-```lua
-require'lspconfig'.sumneko_lua.setup {
-    settings = {
-        Lua = {
-            runtime = {
-                -- Tell the language server which version of Lua you're using (LuaJIT in the case of Neovim)
-                version = 'LuaJIT',
-                -- Setup your lua path
-                path = vim.split(package.path, ';'),
-            },
-            diagnostics = {
-                -- Get the language server to recognize the `vim` global
-                globals = {'vim'},
-            },
-            workspace = {
-                -- Make the server aware of Neovim runtime files
-                library = {
-                    [vim.fn.expand('$VIMRUNTIME/lua')] = true,
-                    [vim.fn.expand('$VIMRUNTIME/lua/vim/lsp')] = true,
-                },
-            },
-        },
-    },
-}
-```
+The [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/) repository contains [instructions to configure sumneko/lua-language-server](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#sumneko_lua) (the example uses the built-in LSP client but the configuration should be identical for other LSP client implementations).
 
 For more information on how to configure [sumneko/lua-language-server](https://github.com/sumneko/lua-language-server/) see ["Setting without VSCode"](https://github.com/sumneko/lua-language-server/wiki/Setting-without-VSCode)
 

--- a/doc/nvim-lua-guide.txt
+++ b/doc/nvim-lua-guide.txt
@@ -1121,38 +1121,11 @@ its  documentation: https://luacheck.readthedocs.io/en/stable/config.html
 
 sumneko/lua-language-server~
 
-Example configuration for  sumneko/lua-language-server:
-https://github.com/sumneko/lua-language-server/   the example uses the
-built-in LSP client but the configuration should be identical for other
-LSP client implementations :
-
-    >
-    require'lspconfig'.sumneko_lua.setup {
-	settings = {
-	    Lua = {
-		runtime = {
-		    -- Tell the language server which version of Lua
-		    you're using (LuaJIT in the case of Neovim)
-		    version = 'LuaJIT',
-		    -- Setup your lua path
-		    path = vim.split(package.path, ';'),
-		},
-		diagnostics = {
-		    -- Get the language server to recognize the `vim`
-		    global
-		    globals = {'vim'},
-		},
-		workspace = {
-		    -- Make the server aware of Neovim runtime files
-		    library = {
-			[vim.fn.expand('$VIMRUNTIME/lua')] = true,
-			[vim.fn.expand('$VIMRUNTIME/lua/vim/lsp')] = true,
-		    },
-		},
-	    },
-	},
-    }
-<
+The  nvim-lspconfig: https://github.com/neovim/nvim-lspconfig/	repository
+contains  instructions to configure sumneko/lua-language-server:
+https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#sumneko_lua
+the example uses the built-in LSP client but the configuration should
+be identical for other LSP client implementations .
 
 For more information on how to configure  sumneko/lua-language-server:
 https://github.com/sumneko/lua-language-server/


### PR DESCRIPTION
It probably makes more sense for this info to be in the `nvim-lspconfig` repo (the example is even more detailed)

Thanks for the stellar work on the built-in LSP client and `nvim-lspconfig` these past few days @mjlbach & everyone contributing :)