### PR TITLE
Fix dead tutorial links for plugins in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Note: the version of Lua that Neovim embeds is [LuaJIT](https://staff.fnwi.uva.n
 A few tutorials have already been written to help people write plugins in Lua. Some of them helped quite a bit when writing this guide. Many thanks to their authors.
 
 - [teukka.tech - From init.vim to init.lua](https://teukka.tech/luanvim.html)
-- [2n.pl - How to write neovim plugins in Lua](https://www.2n.pl/blog/how-to-write-neovim-plugins-in-lua.md)
-- [2n.pl - How to make UI for neovim plugins in Lua](https://www.2n.pl/blog/how-to-make-ui-for-neovim-plugins-in-lua)
+- [dev.to - How to write neovim plugins in Lua](https://dev.to/2nit/how-to-write-neovim-plugins-in-lua-5cca)
+- [dev.to - How to make UI for neovim plugins in Lua](https://dev.to/2nit/how-to-make-ui-for-neovim-plugins-in-lua-3b6e)
 - [ms-jpq - Neovim Async Tutorial](https://ms-jpq.github.io/neovim-async-tutorial/)
 - [oroques.dev - Neovim 0.5 features and the switch to init.lua](https://oroques.dev/notes/neovim-init/)
 


### PR DESCRIPTION
The tutorial links for plugin writing were dead. These are the same articles at a site with a valid security certificate and no login required.