### PR TITLE
Update `_G.dump()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,10 +407,10 @@ This list is by no means comprehensive. If you wish to know more about what's ma
 Writing `print(vim.inspect(x))` every time you want to inspect the contents of an object can get pretty tedious. It might be worthwhile to have a global wrapper function somewhere in your configuration:
 
 ```lua
-function _G.dump(...)
-  local objects, v = {}, nil
+function _G.put(...)
+  local objects = {}
   for i = 1, select('#', ...) do
-    v = select(i, ...)
+    local v = select(i, ...)
     table.insert(objects, vim.inspect(v))
   end
 
@@ -422,11 +422,11 @@ end
 You can then inspect the contents of an object very quickly in your code or from the command-line:
 
 ```lua
-dump({1, 2, 3})
+put({1, 2, 3})
 ```
 
 ```vim
-:lua dump(vim.loop)
+:lua put(vim.loop)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -408,9 +408,14 @@ Writing `print(vim.inspect(x))` every time you want to inspect the contents of a
 
 ```lua
 function _G.dump(...)
-    local objects = vim.tbl_map(vim.inspect, {...})
-    print(unpack(objects))
-    return ...
+  local objects, v = {}, nil
+  for i = 1, select('#', ...) do
+    v = select(i, ...)
+    table.insert(objects, vim.inspect(v))
+  end
+
+  print(table.concat(objects, '\n'))
+  return ...
 end
 ```
 


### PR DESCRIPTION
This modifies code of `_G.dump()` to make it more explicit with `nil` values. Now `dump(nil)` will print `nil` instead of not doing anything.
This also changes printing of multiple arguments: it will print on separate lines instead of separated with spaces.

Also I would like to suggest a name change. Although it is an understandable and used term, "dump" has a somewhat unpleasant connotations to it at first. Here are some alternatives: `put` (my personal favorite), `look`, `view`, `see`, 