### PR TITLE
Remove unneeded commands in the vim.cmd() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,11 +495,9 @@ Alias for `vim.api.nvim_exec()`. Only the command argument is needed, `output` i
 ```lua
 vim.cmd('buffers')
 vim.cmd([[
-let g:multiline =<< EOF
 foo
 bar
 baz
-EOF
 ]])
 ```
 

--- a/doc/nvim-lua-guide.txt
+++ b/doc/nvim-lua-guide.txt
@@ -603,11 +603,9 @@ Alias for `vim.api.nvim_exec()`. Only the command argument is needed,
     >
     vim.cmd('buffers')
     vim.cmd([[
-    let g:multiline =<< EOF
     foo
     bar
     baz
-    EOF
     ]])
 <
 


### PR DESCRIPTION
I have found out that using `vim.cmd()` (originally added to the guide in  [f56cea7](https://github.com/nanotee/nvim-lua-guide/commit/f56cea7de89fc8caf064555594c3808b245d0e5b)) with `let g:multiline =<< EOF <multi-line vimscript> EOF` doesn't always work.

While trying to solve this problem I came across the following section in the [Nvim API documentation](https://neovim.io/doc/user/api.htmlhttps://neovim.io/doc/user/api.html#nvim_exec()):

```txt
nvim_exec({src}, {output})                                       *nvim_exec()*
                Executes Vimscript (multiline block of Ex-commands), like
                anonymous |:source|.
…
                Parameters: 
                    {src}     Vimscript code
…
```

Nowhere does it say that `let g:multiline` is necessary, and on top of that, by removing it my Vimscript code started working.