### PR TITLE
Update user commands definition section

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,9 +944,16 @@ vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
 
 ## Defining user commands
 
-The interface to create user commands was implemented on the PR below and is currently available on neovim 0.7+ (nightly):
+The interface to create user commands was implemented on the PR below and is currently available only on neovim 0.7+ (nightly):
 
 - [Pull request #16752](https://github.com/neovim/neovim/pull/16752)
+
+- Global user command:
+  - [`nvim_add_user_command()`](https://neovim.io/doc/user/api.html#nvim_add_user_command())
+  - [`nvim_del_user_command()`](https://neovim.io/doc/user/api.html#nvim_del_user_command())
+- Buffer-local user commands:
+  - [`nvim_buf_add_user_command()`](https://neovim.io/doc/user/api.html#nvim_buf_add_user_command())
+  - [`nvim_buf_del_user_command()`](https://neovim.io/doc/user/api.html#nvim_buf_del_user_command())
 
 ## Defining autocommands
 

--- a/README.md
+++ b/README.md
@@ -944,11 +944,9 @@ vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
 
 ## Defining user commands
 
-There is currently no interface to create user commands in Lua. It is planned, though:
+The interface to create user commands was implemented on the PR below and is currently available on neovim 0.7+ (nightly):
 
-- [Pull request #11613](https://github.com/neovim/neovim/pull/11613)
-
-For the time being, you're probably better off creating commands in Vimscript.
+- [Pull request #16752](https://github.com/neovim/neovim/pull/16752)
 
 ## Defining autocommands
 

--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ vim.api.nvim_buf_del_keymap(0, 'i', '<Tab>')
 
 ## Defining user commands
 
-The interface to create user commands was implemented on the PR below and is currently available only on neovim 0.7+ (nightly):
+The interface to create user commands was implemented in the PR below and is currently available only in neovim 0.7+ (nightly):
 
 - [Pull request #16752](https://github.com/neovim/neovim/pull/16752)
 

--- a/doc/nvim-lua-guide.txt
+++ b/doc/nvim-lua-guide.txt
@@ -1141,13 +1141,17 @@ first argument, with `0` representing the current buffer.
 DEFINING USER COMMANDS
                                                *luaguide-defining-user-commands*
 
-There is currently no interface to create user commands in Lua. It is
-planned, though:
+The interface to create user commands was implemented in the PR below
+and is currently available only in neovim 0.7+ (nightly):
 
--  Pull request #11613: https://github.com/neovim/neovim/pull/11613
+-  Pull request #16752: https://github.com/neovim/neovim/pull/16752
 
-For the time being, you're probably better off creating commands in
-Vimscript.
+- Global user command:
+  - |nvim_add_user_command()|
+  - |nvim_del_user_command()|
+- Buffer-local user commands:
+  - |nvim_buf_add_user_command()|
+  - |nvim_buf_del_user_command()|
 
 ==============================================================================
 DEFINING AUTOCOMMANDS


### PR DESCRIPTION
As the PR that implements [`nvim_{add,del}_user_command`](https://github.com/neovim/neovim/pull/16752) was recently merged (~ 25 days ago at the time of writing this) and currently can be used on nightly versions of neovim, this section deserves a update to better reflect the current state of such feature